### PR TITLE
Build a universal binary for the Mono executable.

### DIFF
--- a/build_runtime_osx.pl
+++ b/build_runtime_osx.pl
@@ -500,9 +500,7 @@ sub build_osx
 
 	mkpath ("$distdir/bin");
 	for my $file ('mono','pedump') {
-		system ('lipo', "$distdir/bin-i386/$file", '-create', '-output', "$distdir/bin/$file");
-		# Don't add 64bit executables for now...
-		# system ('lipo', "$buildsroot/monodistribution/bin-i386/$file", "$buildsroot/monodistribution/bin-x86_64/$file", '-create', '-output', "$buildsroot/monodistribution/bin/$file");
+		system ('lipo', "$buildsroot/monodistribution/bin-i386/$file", "$buildsroot/monodistribution/bin-x86_64/$file", '-create', '-output', "$buildsroot/monodistribution/bin/$file");
 	}
 
 	mkpath ("$distdir/lib");


### PR DESCRIPTION
- For the IL2CPP unit tests, we are seeing some unexplained hangs in Mono on 64-bit OSX.
- This change should allow us to use a 32-bit version of Mono until we can sort out the problems.
