### PR TITLE
Build Runtime and Classlibs for Linux on Windows Subsystem for Linux

### DIFF
--- a/build.pl
+++ b/build.pl
@@ -374,7 +374,7 @@ if ($build)
 			chdir("$monoroot") eq 1 or die ("failed to chdir to $monoroot\n");
 		}
 
-		if (!(-d "$texinfoDir"))
+		if (!(-d "$texinfoDir") and $windowsSubsystemForLinux)
 		{
 			chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
 			system("tar xzf texinfo-$texinfoVersion.tar.gz") eq 0 or die ("failed to extract texinfo\n");

--- a/build.pl
+++ b/build.pl
@@ -64,6 +64,7 @@ my $tizenEmulator=0;
 my $aotProfile="";
 my $aotProfileDestName="";
 my $disableNormalProfile=0;
+my $isWindowsSubsystemForLinux=0;
 
 # Handy troubleshooting/niche options
 my $skipMonoMake=0;
@@ -195,6 +196,15 @@ if($^O eq "linux")
 {
 	$monoHostArch = $arch32 ? "i686" : "x86_64";
 	$existingExternalMono = "$existingExternalMonoRoot/linux";
+
+	#The build is running through windows subsystem for linux. Here we can build the classlibs
+	#But at the moment there are issues building the runtime that need more time to work through
+	if (`which notepad.exe` ne "")
+	{
+		$isWindowsSubsystemForLinux = 1;
+		$skipMonoMake = 1;
+		$artifact = 0;
+	}
 }
 elsif($^O eq 'darwin')
 {
@@ -346,11 +356,13 @@ if ($build)
 	if ($externalBuildDeps ne "")
 	{
 		print "\n";
-		print ">>> Building autoconf, automake, and libtool if needed...\n";
+		print ">>> Building autoconf, texinfo, automake, and libtool if needed...\n";
 		my $autoconfVersion = "2.69";
+		my $texinfoVersion = "4.8";
 		my $automakeVersion = "1.15";
 		my $libtoolVersion = "2.4.6";
 		my $autoconfDir = "$externalBuildDeps/autoconf-$autoconfVersion";
+		my $texinfoDir = "$externalBuildDeps/texinfo-$texinfoVersion";
 		my $automakeDir = "$externalBuildDeps/automake-$automakeVersion";
 		my $libtoolDir = "$externalBuildDeps/libtool-$libtoolVersion";
 		my $builtToolsDir = "$externalBuildDeps/built-tools";
@@ -370,16 +382,44 @@ if ($build)
 			chdir("$monoroot") eq 1 or die ("failed to chdir to $monoroot\n");
 		}
 
+		if($isWindowsSubsystemForLinux)
+		{
+			if (!(-d "$texinfoDir"))
+			{
+				chdir("$externalBuildDeps");
+				system("tar xzf texinfo-$texinfoVersion.tar.gz") eq 0 or die ("failed to extract texinfo\n");
+
+				chdir("$texinfoDir/doc/amhello");
+				system("./configure --prefix=$builtToolsDir");
+
+				chdir($texinfoDir);
+				system("./configure --prefix=$builtToolsDir");
+				system("make");
+				system("make install");
+
+				chdir("$monoroot");
+			}
+		}
+
 		if (!(-d "$automakeDir"))
 		{
 			chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
 			system("tar xzf automake-$automakeVersion.tar.gz") eq 0  or die ("failed to extract automake\n");
 
 			chdir("$automakeDir") eq 1 or die ("failed to chdir to automake directory\n");
-			system("./configure --prefix=$builtToolsDir") eq 0 or die ("failed to configure automake\n");
-			system("make") eq 0 or die ("failed to make automake\n");
-			system("make install") eq 0 or die ("failed to make install automake\n");
-
+			if($isWindowsSubsystemForLinux)
+			{
+				#Windows subsystem needs to run bootstrap, and make needs to be run with -i due to one doc failing to build
+				system("./bootstrap.sh") eq 0 or die ("failed to boostrap automake\n");
+				system("./configure --prefix=$builtToolsDir") eq 0 or die ("failed to configure automake\n");
+				system("make -i");
+			}
+			else
+			{
+				system("./configure --prefix=$builtToolsDir") eq 0 or die ("failed to configure automake\n");
+				system("make") eq 0 or die ("failed to make automake\n");
+			}
+			system("make install");
 			chdir("$monoroot") eq 1 or die ("failed to chdir to $monoroot\n");
 		}
 
@@ -1335,6 +1375,13 @@ if ($buildUsAndBoo)
 	if (not $disableNormalProfile)
 	{
 		print(">>> Building Unity Script and Boo...\n");
+		if($isWindowsSubsystemForLinux)
+		{
+			#boo scripts expect a bin-platform folder, but we haven't built them that way
+			system("ln -s $monoprefix/bin $monoprefix/bin-linux64");
+			system("ln -s $monoprefix/bin $monoprefix/bin-linux32");
+		}
+
 		system("perl", "$buildscriptsdir/build_us_and_boo.pl", "--monoprefix=$monoprefix") eq 0 or die ("Failed building Unity Script and Boo\n");
 
 		if ($aotProfile ne "")

--- a/build.pl
+++ b/build.pl
@@ -376,22 +376,20 @@ if ($build)
 
 		if (!(-d "$texinfoDir"))
 		{
-			chdir("$externalBuildDeps");
+			chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
 			system("tar xzf texinfo-$texinfoVersion.tar.gz") eq 0 or die ("failed to extract texinfo\n");
 
-			chdir("$texinfoDir/doc/amhello");
-			system("./configure --prefix=$builtToolsDir");
+			chdir($texinfoDir) eq 1 or die ("failed to chdir to texinfo directory\n");
+			system("./configure --prefix=$builtToolsDir") eq 0 or die ("failed to configure texinfo\n");
+			system("make") eq 0 or die ("failed to make texinfo\n");
+			system("make install") eq 0 or die ("failed to make install texinfo\n");
 
-			chdir($texinfoDir);
-			system("./configure --prefix=$builtToolsDir");
-			system("make");
-			system("make install");
-
-			chdir("$monoroot");
+			chdir("$monoroot") eq 1 or die ("failed to chdir to $monoroot\n");
 		}
 
 		if (!(-d "$automakeDir"))
 		{
+			my $automakeMakeFlags = "";
 			chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
 			system("tar xzf automake-$automakeVersion.tar.gz") eq 0  or die ("failed to extract automake\n");
 
@@ -399,15 +397,11 @@ if ($build)
 			if($windowsSubsystemForLinux)
 			{
 				#Windows subsystem needs to run bootstrap, and make needs to be run with -i due to one doc failing to build
-				system("./bootstrap.sh") eq 0 or die ("failed to boostrap automake\n");
-				system("./configure --prefix=$builtToolsDir") eq 0 or die ("failed to configure automake\n");
-				system("make -i");
+				system("./bootstrap.sh") eq 0 or die ("failed to bootstrap automake\n");
+				$automakeMakeFlags = "-i";
 			}
-			else
-			{
-				system("./configure --prefix=$builtToolsDir") eq 0 or die ("failed to configure automake\n");
-				system("make") eq 0 or die ("failed to make automake\n");
-			}
+			system("./configure --prefix=$builtToolsDir") eq 0 or die ("failed to configure automake\n");
+			system("make $automakeMakeFlags") eq 0 or die ("failed to make automake\n");
 			system("make install");
 			chdir("$monoroot") eq 1 or die ("failed to chdir to $monoroot\n");
 		}

--- a/build.pl
+++ b/build.pl
@@ -202,7 +202,7 @@ if($^O eq "linux")
 	if (`which notepad.exe` ne "")
 	{
 		$isWindowsSubsystemForLinux = 1;
-		$skipMonoMake = 1;
+		#$skipMonoMake = 1;
 		$artifact = 0;
 	}
 }

--- a/build_classlibs_wsl.pl
+++ b/build_classlibs_wsl.pl
@@ -1,0 +1,37 @@
+use Cwd;
+use Cwd 'abs_path';
+use Getopt::Long;
+use File::Basename;
+use File::Path;
+
+my $monoroot = File::Spec->rel2abs(dirname(__FILE__) . "/../..");
+my $monoroot = abs_path($monoroot);
+my $buildScriptsRoot = "$monoroot/external/buildscripts";
+
+my $build = 1;
+my $clean = 1;
+
+# Handy troubleshooting/niche options
+
+# The prefix hack probably isn't needed anymore.  Let's disable it by default and see how things go
+my $shortPrefix = 1;
+
+GetOptions(
+   "build=i"=>\$build,
+   "clean=i"=>\$clean,
+   'shortprefix=i'=>\$shortPrefix,
+) or die ("illegal cmdline options");
+
+system(
+	"perl",
+	"$buildScriptsRoot/build.pl",
+	"--build=$build",
+	"--clean=$clean",
+	"--artifact=1",
+	"--artifactscommon=1",
+	"--aotprofile=mobile_static",
+	"--aotprofiledestname=unity_aot",
+	"--buildusandboo=1",
+	"--forcedefaultbuilddeps=1",
+	"--windowssubsystemforlinux=1",
+	"--shortprefix=$shortPrefix") eq 0 or die ("Failed building mono\n");

--- a/build_runtime_wsl.pl
+++ b/build_runtime_wsl.pl
@@ -1,0 +1,13 @@
+use Cwd;
+use Cwd 'abs_path';
+use Getopt::Long;
+use File::Basename;
+use File::Path;
+
+my $monoroot = File::Spec->rel2abs(dirname(__FILE__) . "/../..");
+my $monoroot = abs_path($monoroot);
+my $buildScriptsRoot = "$monoroot/external/buildscripts";
+
+#Windows Subsystem for Linux currently does not support 32-bit, so the option is 64-bit only
+
+system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=1", "--test=1", "--artifact=1", "--arch32=0", "--classlibtests=0", "--forcedefaultbuilddeps=1", "--windowssubsystemforlinux=1") eq 0 or die ("Failed building mono\n");


### PR DESCRIPTION
Windows subsystem for linux is Cononical's Ubuntu and shell running ontop of the windows operating system. We currently have no solution for building class librarys on windows. As such in the past classlib changes were painful, requiring us to either sacrifice the superior windows debugging environment, or make changes on our macs, build and copy things back to windows, or setup shared filesystem solutions. These changes enable us to build the classlibs on windows subsystem for linux for faster iteration time on classlib related bugs. Since starting this I have already benefited from this backporting classlib changes from 5.0 to 4.8 and testing them all without logging into mac.

Summary of Changes:
Texinfo was previously assumed to be installed on the build machine, however windows subsystem for linux ships a version that is *too new so it gives us failures building documentation for the other dependencies (like automake). As such I've packaged the GNU texinfo code in mono-build-deps (merged already) and here we make use of this packaged version of texinfo. A few minor changes due to filesystem structure were made on the condition that we're running on windows subsystem for linux. Its possible that regular linux has these problems building classlibs since we don't usually do this, but for now they'll only work differently when running on wsl.  Two new files have been added build_runtime_wsl.pl and build_classlibs_wsl.pl. Due to limitations in the windows subsystem for linux, build_runtime_wsl will only build mono in 64-bit

Testing:
- I've run both my new scripts build_runtime_wsl.pl and build_classlibs_wsl.pl with a fresh checkout (and thus also fresh dependencies) and both seem to be working as they should
- I've built everything on katana using these changes, with the new dependency I added and katana shows all platforms green